### PR TITLE
Add Backpack order book data source

### DIFF
--- a/hummingbot/connector/exchange/backpack_exchange/backpack_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/backpack_exchange/backpack_api_order_book_data_source.py
@@ -1,0 +1,140 @@
+import asyncio
+import time
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+from hummingbot.connector.exchange.backpack_exchange import backpack_constants as CONSTANTS
+from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
+from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTrackerDataSource
+from hummingbot.core.web_assistant.connections.data_types import RESTMethod, WSJSONRequest
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+from hummingbot.core.web_assistant.ws_assistant import WSAssistant
+from hummingbot.logger import HummingbotLogger
+
+if TYPE_CHECKING:
+    from .backpack_exchange import BackpackExchange
+
+
+class BackpackAPIOrderBookDataSource(OrderBookTrackerDataSource):
+    """Order book data source for Backpack exchange."""
+
+    _logger: Optional[HummingbotLogger] = None
+
+    def __init__(self,
+                 trading_pairs: List[str],
+                 connector: 'BackpackExchange',
+                 api_factory: WebAssistantsFactory,
+                 domain: str = CONSTANTS.DEFAULT_DOMAIN):
+        super().__init__(trading_pairs)
+        self._connector = connector
+        self._api_factory = api_factory
+        self._domain = domain
+        self._channel_associated_to_pair: Dict[str, str] = {}
+
+    async def get_last_traded_prices(self,
+                                     trading_pairs: List[str],
+                                     domain: Optional[str] = None) -> Dict[str, float]:
+        return await self._connector.get_last_traded_prices(trading_pairs=trading_pairs)
+
+    async def _request_order_book_snapshot(self, trading_pair: str) -> Dict[str, Any]:
+        params = {
+            "symbol": await self._connector.exchange_symbol_associated_to_pair(trading_pair=trading_pair),
+        }
+        rest_assistant = await self._api_factory.get_rest_assistant()
+        data = await rest_assistant.execute_request(
+            url=f"{CONSTANTS.REST_URL}{CONSTANTS.ORDER_BOOK_PATH_URL}",
+            params=params,
+            method=RESTMethod.GET,
+            throttler_limit_id=CONSTANTS.ORDER_BOOK_PATH_URL,
+        )
+        return data
+
+    async def _order_book_snapshot(self, trading_pair: str) -> OrderBookMessage:
+        snapshot = await self._request_order_book_snapshot(trading_pair)
+        timestamp = float(snapshot.get("ts")) / 1000
+        message = {
+            "trading_pair": trading_pair,
+            "update_id": timestamp,
+            "bids": snapshot.get("bids", []),
+            "asks": snapshot.get("asks", []),
+        }
+        return OrderBookMessage(OrderBookMessageType.SNAPSHOT, message, timestamp)
+
+    async def _connected_websocket_assistant(self) -> WSAssistant:
+        ws: WSAssistant = await self._api_factory.get_ws_assistant()
+        await ws.connect(
+            ws_url=CONSTANTS.WSS_PUBLIC_URL,
+            ping_timeout=CONSTANTS.WS_HEARTBEAT_TIME_INTERVAL,
+        )
+        return ws
+
+    async def _subscribe_channels(self, ws: WSAssistant):
+        try:
+            for trading_pair in self._trading_pairs:
+                symbol = await self._connector.exchange_symbol_associated_to_pair(trading_pair=trading_pair)
+                trade_payload = {"op": "subscribe", "channel": f"trades.{symbol}"}
+                depth_payload = {"op": "subscribe", "channel": f"depth.{symbol}"}
+                await ws.send(WSJSONRequest(payload=trade_payload))
+                await ws.send(WSJSONRequest(payload=depth_payload))
+                self._channel_associated_to_pair[f"trades.{symbol}"] = trading_pair
+                self._channel_associated_to_pair[f"depth.{symbol}"] = trading_pair
+            self.logger().info("Subscribed to public order book and trade channels...")
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            self.logger().error(
+                "Unexpected error occurred subscribing to order book trading and delta streams...",
+                exc_info=True,
+            )
+            raise
+
+    async def _parse_trade_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
+        channel = raw_message.get("channel")
+        trading_pair = self._channel_associated_to_pair.get(channel)
+        data = raw_message.get("data") or {}
+        trades = data if isinstance(data, list) else [data]
+        for trade in trades:
+            ts = float(trade.get("ts") or trade.get("t", time.time() * 1000)) / 1000
+            side = str(trade.get("side", "buy")).lower()
+            price = float(trade.get("p") or trade.get("price"))
+            amount = float(trade.get("q") or trade.get("size"))
+            message = OrderBookMessage(
+                OrderBookMessageType.TRADE,
+                {
+                    "trading_pair": trading_pair,
+                    "trade_type": 1.0 if side == "buy" else 2.0,
+                    "trade_id": ts,
+                    "update_id": ts,
+                    "price": price,
+                    "amount": amount,
+                },
+                ts,
+            )
+            message_queue.put_nowait(message)
+
+    async def _parse_order_book_diff_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
+        channel = raw_message.get("channel")
+        trading_pair = self._channel_associated_to_pair.get(channel)
+        data = raw_message.get("data") or {}
+        ts = float(data.get("ts") or data.get("t", time.time() * 1000)) / 1000
+        message = OrderBookMessage(
+            OrderBookMessageType.DIFF,
+            {
+                "trading_pair": trading_pair,
+                "update_id": ts,
+                "bids": data.get("bids") or data.get("b", []),
+                "asks": data.get("asks") or data.get("a", []),
+            },
+            ts,
+        )
+        message_queue.put_nowait(message)
+
+    async def _parse_order_book_snapshot_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
+        await self._parse_order_book_diff_message(raw_message, message_queue)
+
+    def _channel_originating_message(self, event_message: Dict[str, Any]) -> str:
+        channel = event_message.get("channel", "")
+        if channel.startswith("trades."):
+            return self._trade_messages_queue_key
+        if channel.startswith("depth."):
+            return self._diff_messages_queue_key
+        return ""

--- a/tasks/task_3.txt
+++ b/tasks/task_3.txt
@@ -1,6 +1,6 @@
 # Task ID: 3
 # Title: Develop Public Order Book Data Source
-# Status: todo
+# Status: done
 # Dependencies: 2
 # Priority: high
 # Description: Implement BackpackAPIOrderBookDataSource to provide order book snapshots and incremental updates via WebSocket.

--- a/test/hummingbot/connector/exchange/backpack_exchange/__init__.py
+++ b/test/hummingbot/connector/exchange/backpack_exchange/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Backpack exchange connector"""

--- a/test/hummingbot/connector/exchange/backpack_exchange/test_backpack_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/backpack_exchange/test_backpack_api_order_book_data_source.py
@@ -1,0 +1,113 @@
+import asyncio
+import json
+import re
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from aioresponses import aioresponses
+from bidict import bidict
+
+from hummingbot.connector.exchange.backpack_exchange import backpack_constants as CONSTANTS
+from hummingbot.connector.exchange.backpack_exchange.backpack_api_order_book_data_source import (
+    BackpackAPIOrderBookDataSource,
+)
+from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
+from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from hummingbot.core.data_type.order_book_message import OrderBookMessageType
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+
+
+class BackpackAPIOrderBookDataSourceTests(IsolatedAsyncioWrapperTestCase):
+    level = 0
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        cls.trading_pair = "BTC-USDT"
+        cls.ex_trading_pair = "BTC_USDT"
+
+    async def asyncSetUp(self) -> None:
+        await super().asyncSetUp()
+        self.log_records = []
+        self.listening_task = None
+        self.mocking_assistant = NetworkMockingAssistant()
+
+        throttler = AsyncThrottler(CONSTANTS.RATE_LIMITS)
+        self.api_factory = WebAssistantsFactory(throttler=throttler)
+
+        self.connector = MagicMock()
+        self.connector._web_assistants_factory = self.api_factory
+        self.connector.get_last_traded_prices = AsyncMock(return_value={})
+        self.connector.exchange_symbol_associated_to_pair = AsyncMock(return_value=self.ex_trading_pair)
+        self.connector.trading_pair_associated_to_exchange_symbol = AsyncMock(return_value=self.trading_pair)
+
+        self.data_source = BackpackAPIOrderBookDataSource(
+            trading_pairs=[self.trading_pair],
+            connector=self.connector,
+            api_factory=self.api_factory,
+        )
+
+        self.data_source.logger().setLevel(1)
+        self.data_source.logger().addHandler(self)
+
+    def tearDown(self) -> None:
+        self.listening_task and self.listening_task.cancel()
+        super().tearDown()
+
+    def handle(self, record):
+        self.log_records.append(record)
+
+    def _snapshot_response(self):
+        return {
+            "ts": 1700000000000,
+            "bids": [["100", "1"]],
+            "asks": [["101", "2"]],
+        }
+
+    @aioresponses()
+    async def test_get_new_order_book_successful(self, mock_api):
+        url = f"{CONSTANTS.REST_URL}{CONSTANTS.ORDER_BOOK_PATH_URL}"
+        regex_url = re.compile(f"^{url}")
+        resp = self._snapshot_response()
+        mock_api.get(regex_url, body=json.dumps(resp))
+
+        order_book = await self.data_source.get_new_order_book(self.trading_pair)
+
+        self.assertEqual(resp["ts"] / 1000, order_book.snapshot_uid)
+        self.assertEqual(100.0, list(order_book.bid_entries())[0].price)
+        self.assertEqual(101.0, list(order_book.ask_entries())[0].price)
+
+    @patch("aiohttp.ClientSession.ws_connect", new_callable=AsyncMock)
+    async def test_listen_for_subscriptions_subscribes_to_channels(self, ws_connect_mock):
+        ws_connect_mock.return_value = self.mocking_assistant.create_websocket_mock()
+
+        self.mocking_assistant.add_websocket_aiohttp_message(
+            websocket_mock=ws_connect_mock.return_value, message=json.dumps({})
+        )
+        self.mocking_assistant.add_websocket_aiohttp_message(
+            websocket_mock=ws_connect_mock.return_value, message=json.dumps({})
+        )
+
+        self.listening_task = self.local_event_loop.create_task(self.data_source.listen_for_subscriptions())
+
+        await self.mocking_assistant.run_until_all_aiohttp_messages_delivered(ws_connect_mock.return_value)
+
+        sent_messages = self.mocking_assistant.json_messages_sent_through_websocket(ws_connect_mock.return_value)
+        expected_depth = {"op": "subscribe", "channel": f"depth.{self.ex_trading_pair}"}
+        expected_trade = {"op": "subscribe", "channel": f"trades.{self.ex_trading_pair}"}
+        self.assertIn(expected_depth, sent_messages)
+        self.assertIn(expected_trade, sent_messages)
+
+    async def test_parse_order_book_diff_message(self):
+        self.data_source._channel_associated_to_pair[f"depth.{self.ex_trading_pair}"] = self.trading_pair
+        diff_event = {
+            "channel": f"depth.{self.ex_trading_pair}",
+            "data": {"ts": 1700000000000, "bids": [["100", "1"]], "asks": [["101", "2"]]},
+        }
+        queue: asyncio.Queue = asyncio.Queue()
+        await self.data_source._parse_order_book_diff_message(diff_event, queue)
+        msg = queue.get_nowait()
+        self.assertEqual(OrderBookMessageType.DIFF, msg.type)
+        self.assertEqual(1700000000, msg.update_id)
+
+


### PR DESCRIPTION
## Summary
- implement `BackpackAPIOrderBookDataSource` for REST snapshots and websocket streams
- add unit tests for snapshot retrieval, subscriptions and diff parsing
- mark Task 3 as done

## Testing
- `pytest test/hummingbot/connector/exchange/backpack_exchange/test_backpack_api_order_book_data_source.py -q` *(fails: `pytest` not installed)*