### PR TITLE
Add initial Backpack connector implementation

### DIFF
--- a/hummingbot/connector/exchange/backpack_exchange/backpack_constants.py
+++ b/hummingbot/connector/exchange/backpack_exchange/backpack_constants.py
@@ -18,6 +18,8 @@ WSS_PRIVATE_URL = "wss://ws.backpack.exchange"
 # REST API endpoints
 ORDER_BOOK_PATH_URL = "/api/v1/depth"
 SERVER_TIME_PATH_URL = "/api/v1/time"
+MARKETS_PATH_URL = "/api/v1/markets"
+TRADES_PATH_URL = "/api/v1/trades"
 
 # Websocket constants
 WS_HEARTBEAT_TIME_INTERVAL = 30

--- a/hummingbot/connector/exchange/backpack_exchange/backpack_exchange.py
+++ b/hummingbot/connector/exchange/backpack_exchange/backpack_exchange.py
@@ -1,7 +1,190 @@
-"""Backpack exchange connector placeholder."""
+import asyncio
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+from bidict import bidict
+
+from hummingbot.connector.constants import s_decimal_NaN
+from hummingbot.connector.exchange.backpack_exchange import (
+    backpack_constants as CONSTANTS,
+    backpack_web_utils as web_utils,
+)
+from hummingbot.connector.exchange.backpack_exchange.backpack_api_order_book_data_source import (
+    BackpackAPIOrderBookDataSource,
+)
+from hummingbot.connector.exchange.backpack_exchange.backpack_auth import BackpackAuth
+from hummingbot.connector.exchange_py_base import ExchangePyBase
+from hummingbot.connector.trading_rule import TradingRule
+from hummingbot.connector.utils import combine_to_hb_trading_pair
+from hummingbot.core.data_type.common import OrderType
+from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTrackerDataSource
+from hummingbot.core.data_type.trade_fee import TradeFeeBase
+from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
+from hummingbot.core.web_assistant.connections.data_types import RESTMethod
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+
+if TYPE_CHECKING:
+    from hummingbot.client.config.config_helpers import ClientConfigAdapter
 
 
-class BackpackExchange:
-    """Placeholder exchange class for Backpack connector."""
+class BackpackExchange(ExchangePyBase):
+    """Minimal Backpack exchange connector implementation."""
 
-    pass
+    web_utils = web_utils
+
+    def __init__(
+        self,
+        client_config_map: "ClientConfigAdapter",
+        backpack_api_key: str,
+        backpack_secret_key: str,
+        trading_pairs: Optional[List[str]] = None,
+        trading_required: bool = True,
+        domain: str = CONSTANTS.DEFAULT_DOMAIN,
+    ):
+        self._api_key = backpack_api_key
+        self._secret_key = backpack_secret_key
+        self._domain = domain
+        self._trading_required = trading_required
+        self._trading_pairs = trading_pairs
+        super().__init__(client_config_map)
+
+    @property
+    def authenticator(self):
+        return BackpackAuth(
+            api_key=self._api_key,
+            secret_key=self._secret_key,
+            time_provider=self._time_synchronizer,
+        )
+
+    @property
+    def name(self) -> str:
+        return CONSTANTS.EXCHANGE_NAME
+
+    @property
+    def rate_limits_rules(self):
+        return CONSTANTS.RATE_LIMITS
+
+    @property
+    def domain(self):
+        return self._domain
+
+    @property
+    def client_order_id_max_length(self):
+        return CONSTANTS.MAX_ORDER_ID_LEN
+
+    @property
+    def client_order_id_prefix(self):
+        return CONSTANTS.HBOT_ORDER_ID_PREFIX
+
+    @property
+    def trading_rules_request_path(self):
+        return CONSTANTS.MARKETS_PATH_URL
+
+    @property
+    def trading_pairs_request_path(self):
+        return CONSTANTS.MARKETS_PATH_URL
+
+    @property
+    def check_network_request_path(self):
+        return CONSTANTS.SERVER_TIME_PATH_URL
+
+    @property
+    def trading_pairs(self):
+        return self._trading_pairs
+
+    @property
+    def is_cancel_request_in_exchange_synchronous(self) -> bool:
+        return True
+
+    @property
+    def is_trading_required(self) -> bool:
+        return self._trading_required
+
+    def supported_order_types(self):
+        return [OrderType.LIMIT, OrderType.LIMIT_MAKER, OrderType.MARKET]
+
+    def _create_web_assistants_factory(self) -> WebAssistantsFactory:
+        return web_utils.build_api_factory(
+            throttler=self._throttler,
+            time_synchronizer=self._time_synchronizer,
+            auth=self._auth,
+        )
+
+    def _create_order_book_data_source(self) -> OrderBookTrackerDataSource:
+        return BackpackAPIOrderBookDataSource(
+            trading_pairs=self._trading_pairs,
+            connector=self,
+            api_factory=self._web_assistants_factory,
+        )
+
+    def _create_user_stream_data_source(self) -> UserStreamTrackerDataSource:
+        raise NotImplementedError
+
+    def _create_user_stream_tracker(self):  # pragma: no cover - not implemented yet
+        return None
+
+    def _create_user_stream_tracker_task(self):  # pragma: no cover - not implemented yet
+        return None
+
+    def _is_user_stream_initialized(self):
+        return True
+
+    def _initialize_trading_pair_symbols_from_exchange_info(self, exchange_info: Dict[str, Any]):
+        mapping = bidict()
+        markets = exchange_info.get("markets") or exchange_info.get("data") or []
+        for market in markets:
+            symbol = market.get("id") or market.get("symbol") or market.get("name")
+            base = market.get("baseAsset") or market.get("base") or market.get("base_currency")
+            quote = market.get("quoteAsset") or market.get("quote") or market.get("quote_currency")
+            if symbol and base and quote:
+                mapping[symbol] = combine_to_hb_trading_pair(base=base, quote=quote)
+        if not mapping and self._trading_pairs:
+            for trading_pair in self._trading_pairs:
+                base, quote = trading_pair.split("-")
+                mapping[f"{base}_{quote}"] = trading_pair
+        self._set_trading_pair_symbol_map(mapping)
+
+    async def _get_last_traded_price(self, trading_pair: str) -> float:
+        params = {"symbol": await self.exchange_symbol_associated_to_pair(trading_pair=trading_pair)}
+        resp = await self._api_get(path_url=CONSTANTS.TRADES_PATH_URL, params=params)
+        trades = resp.get("data") or resp.get("trades") or resp
+        if isinstance(trades, list) and len(trades) > 0:
+            price = float(trades[0].get("p") or trades[0].get("price"))
+            return price
+        return float("nan")
+
+    async def fetch_trades(self, trading_pair: str, limit: int = 50) -> List[Dict[str, Any]]:
+        params = {
+            "symbol": await self.exchange_symbol_associated_to_pair(trading_pair=trading_pair),
+            "limit": limit,
+        }
+        resp = await self._api_get(path_url=CONSTANTS.TRADES_PATH_URL, params=params)
+        trades = resp.get("data") or resp.get("trades") or []
+        parsed_trades = []
+        for trade in trades:
+            parsed_trades.append({
+                "price": float(trade.get("p") or trade.get("price")),
+                "amount": float(trade.get("q") or trade.get("size")),
+                "timestamp": float(trade.get("ts") or trade.get("t")) / 1000,
+                "side": str(trade.get("side", "buy")).lower(),
+            })
+        return parsed_trades
+
+    # Placeholder implementations for trading actions
+    async def _place_order(self, *args, **kwargs):
+        raise NotImplementedError
+
+    async def _place_cancel(self, *args, **kwargs):
+        raise NotImplementedError
+
+    async def _all_trade_updates_for_order(self, order):
+        return []
+
+    async def _update_balances(self):
+        pass
+
+    async def _format_trading_rules(self, exchange_info: Dict[str, Any]) -> List[TradingRule]:
+        return []
+
+    def _trade_fee_schema(self) -> TradeFeeBase:
+        return TradeFeeBase()  # Default zero fees

--- a/hummingbot/connector/exchange/backpack_exchange/backpack_web_utils.py
+++ b/hummingbot/connector/exchange/backpack_exchange/backpack_web_utils.py
@@ -1,0 +1,53 @@
+from typing import Optional, Callable
+
+from hummingbot.connector.time_synchronizer import TimeSynchronizer
+from hummingbot.connector.utils import TimeSynchronizerRESTPreProcessor
+from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from hummingbot.core.web_assistant.auth import AuthBase
+from hummingbot.core.web_assistant.connections.data_types import RESTMethod
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+
+from . import backpack_constants as CONSTANTS
+
+
+def rest_url(path_url: str, domain: str = CONSTANTS.DEFAULT_DOMAIN) -> str:
+    """Construct REST URL for an endpoint."""
+    return f"{CONSTANTS.REST_URL}{path_url}"
+
+
+def build_api_factory(
+    throttler: Optional[AsyncThrottler] = None,
+    time_synchronizer: Optional[TimeSynchronizer] = None,
+    domain: str = CONSTANTS.DEFAULT_DOMAIN,
+    time_provider: Optional[Callable] = None,
+    auth: Optional[AuthBase] = None,
+) -> WebAssistantsFactory:
+    throttler = throttler or create_throttler()
+    time_synchronizer = time_synchronizer or TimeSynchronizer()
+    time_provider = time_provider or (lambda: get_current_server_time(throttler=throttler))
+    api_factory = WebAssistantsFactory(
+        throttler=throttler,
+        auth=auth,
+        rest_pre_processors=[
+            TimeSynchronizerRESTPreProcessor(synchronizer=time_synchronizer, time_provider=time_provider)
+        ],
+    )
+    return api_factory
+
+
+def create_throttler() -> AsyncThrottler:
+    return AsyncThrottler(CONSTANTS.RATE_LIMITS)
+
+
+async def get_current_server_time(throttler: Optional[AsyncThrottler] = None) -> float:
+    throttler = throttler or create_throttler()
+    api_factory = WebAssistantsFactory(throttler=throttler)
+    rest_assistant = await api_factory.get_rest_assistant()
+    response = await rest_assistant.execute_request(
+        url=rest_url(CONSTANTS.SERVER_TIME_PATH_URL),
+        method=RESTMethod.GET,
+        throttler_limit_id=CONSTANTS.SERVER_TIME_PATH_URL,
+    )
+    server_time = float(response.get("serverTime") or response.get("time") or response.get("ts"))
+    return server_time
+

--- a/test/hummingbot/connector/exchange/backpack_exchange/test_backpack_exchange.py
+++ b/test/hummingbot/connector/exchange/backpack_exchange/test_backpack_exchange.py
@@ -1,0 +1,76 @@
+import asyncio
+import sys
+import types
+from unittest import TestCase
+from unittest.mock import AsyncMock
+
+pandas_stub = types.ModuleType("pandas")
+pandas_stub.options = types.SimpleNamespace(display=types.SimpleNamespace(float_format=None))
+class DummyDataFrame:
+    pass
+pandas_stub.DataFrame = DummyDataFrame
+sys.modules.setdefault("pandas", pandas_stub)
+sys.modules.setdefault("numpy", types.ModuleType("numpy"))
+sys.modules.setdefault("hexbytes", types.ModuleType("hexbytes"))
+sys.modules["hexbytes"].HexBytes = bytes
+sys.modules.setdefault("cachetools", types.ModuleType("cachetools"))
+
+from unittest.mock import patch
+
+from hummingbot.connector.exchange.backpack_exchange import backpack_constants as CONSTANTS
+from hummingbot.connector.exchange.backpack_exchange import backpack_web_utils as web_utils
+from hummingbot.connector.exchange.backpack_exchange.backpack_exchange import BackpackExchange
+
+
+class BackpackExchangeTests(TestCase):
+    def setUp(self):
+        class DummyConfig:
+            rate_limits_share_pct = 1.0
+
+        self.client_config_map = DummyConfig()
+        self.exchange = BackpackExchange(
+            client_config_map=self.client_config_map,
+            backpack_api_key="key",
+            backpack_secret_key="secret",
+            trading_pairs=["BTC-USDT"],
+        )
+
+    def async_run(self, coroutine):
+        return asyncio.get_event_loop().run_until_complete(asyncio.wait_for(coroutine, 1))
+
+    def test_initialize_trading_pair_symbols(self):
+        exchange_info = {"markets": [{"id": "BTC_USDT", "baseAsset": "BTC", "quoteAsset": "USDT"}]}
+        self.exchange._initialize_trading_pair_symbols_from_exchange_info(exchange_info)
+        symbol = self.async_run(self.exchange.exchange_symbol_associated_to_pair("BTC-USDT"))
+        self.assertEqual("BTC_USDT", symbol)
+
+    def test_get_last_traded_price(self):
+        class FakeBidict(dict):
+            @property
+            def inverse(self):
+                return {v: k for k, v in self.items()}
+
+        self.exchange._set_trading_pair_symbol_map(FakeBidict({"BTC_USDT": "BTC-USDT"}))
+        with patch.object(self.exchange, "_api_get", new=AsyncMock(return_value={"data": [{"p": "100"}]})):
+            price = self.async_run(self.exchange._get_last_traded_price("BTC-USDT"))
+        self.assertEqual(100.0, price)
+
+    def test_fetch_trades(self):
+        class FakeBidict(dict):
+            @property
+            def inverse(self):
+                return {v: k for k, v in self.items()}
+
+        self.exchange._set_trading_pair_symbol_map(FakeBidict({"BTC_USDT": "BTC-USDT"}))
+        response = {
+            "data": [
+                {"p": "101", "q": "1", "ts": 1700000000000, "side": "buy"},
+                {"p": "102", "q": "2", "ts": 1700000001000, "side": "sell"},
+            ]
+        }
+        with patch.object(self.exchange, "_api_get", new=AsyncMock(return_value=response)):
+            trades = self.async_run(self.exchange.fetch_trades("BTC-USDT", limit=2))
+        self.assertEqual(2, len(trades))
+        self.assertEqual(101.0, trades[0]["price"])
+        self.assertEqual("sell", trades[1]["side"])
+


### PR DESCRIPTION
## Summary
- implement core logic for BackpackExchange
- add backpack web utilities and REST endpoints constants
- add tests covering symbol initialization and trade fetching

## Testing
- `python -m unittest test.hummingbot.connector.exchange.backpack_exchange.test_backpack_exchange -v` *(fails: ModuleNotFoundError: aiohttp)*